### PR TITLE
Feature/inactive cloudwatch loggroup/recommendation

### DIFF
--- a/bumiworker/bumiworker/modules/pricing/aws_cloudwatch.py
+++ b/bumiworker/bumiworker/modules/pricing/aws_cloudwatch.py
@@ -21,7 +21,3 @@ DEFAULT = CloudWatchLogsPricing(
     compression_factor=0.15,
 )
 
-# if you want granularity by region later:
-BY_REGION: Mapping[str, CloudWatchLogsPricing] = {
-    # "us-east-1": CloudWatchLogsPricing(...),
-}

--- a/bumiworker/bumiworker/modules/pricing/aws_cloudwatch.py
+++ b/bumiworker/bumiworker/modules/pricing/aws_cloudwatch.py
@@ -1,0 +1,27 @@
+"""
+Pricing for AWS CloudWatch Logs
+See: https://aws.amazon.com/cloudwatch/pricing/ (values may vary by region)
+
+"""
+from dataclasses import dataclass
+from typing import Mapping
+
+@dataclass(frozen=True)
+class CloudWatchLogsPricing:
+    storage_usd_per_gb_month: float
+    ingestion_usd_per_gb: float
+    query_usd_per_gb: float
+    compression_factor: float  
+
+# from Virginia US
+DEFAULT = CloudWatchLogsPricing(
+    storage_usd_per_gb_month=0.03,
+    ingestion_usd_per_gb=0.50,
+    query_usd_per_gb=0.005,
+    compression_factor=0.15,
+)
+
+# if you want granularity by region later:
+BY_REGION: Mapping[str, CloudWatchLogsPricing] = {
+    # "us-east-1": CloudWatchLogsPricing(...),
+}

--- a/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
+++ b/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
@@ -1,7 +1,7 @@
 import logging
 from collections import OrderedDict
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Any
 from enum import Enum
 from bumiworker.bumiworker.modules.base import ModuleBase
 from bumiworker.bumiworker.modules.pricing.aws_cloudwatch import CloudWatchLogsPricing, DEFAULT as CWL_PRICING
@@ -13,7 +13,6 @@ LOG = logging.getLogger(__name__)
 BYTES_PER_GIB = 1024 ** 3  
 RECENT_WINDOW_DAYS_DEFAULT = 30
 DEAD_RESOURCE_DAYS_DEFAULT = 30
-MIN_STORAGE_BYTES_DEFAULT = 1 * 1024 * 1024 
 
 class MetricKey(str, Enum):
     INGESTION = "IngestionBytes"
@@ -29,13 +28,30 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         super().__init__(organization_id, config_client, created_at)
         self.option_ordered_map = OrderedDict({
             'dead_resource_days': {'default': DEAD_RESOURCE_DAYS_DEFAULT},
-            'min_storage_bytes': {'default': MIN_STORAGE_BYTES_DEFAULT},
             'excluded_pools': {
                 'default': {},
                 'clean_func': self.clean_excluded_pools,
             },
             'skip_cloud_accounts': {'default': []}
         })
+
+
+    def _utc_now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _parse_ts(self, ts: Any) -> Optional[datetime]:
+        if ts is None:
+            return None
+        try:
+            if isinstance(ts, (int, float)):
+                return datetime.fromtimestamp(float(ts), tz=timezone.utc)
+            s = str(ts)
+            if s.endswith("Z"): 
+                s = s.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(s)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except Exception:
+            return None
 
     def _get_from_resource(self, resource: Dict, key: str, default=None):
         """
@@ -55,19 +71,19 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             return metrics
         return (resource.get('meta', {}) or {}).get('metrics', {}) or {}
 
-    def _sum_metrics_recent_window(self, series: List[Dict]) -> float:
+    def _sum_metrics_last_month(self, series: List[Dict]) -> float:
         """
-        Sum metric values within the recent window (RECENT_WINDOW_DAYS).
+        Sum metric values within the recent window (RECENT_WINDOW_DAYS_DEFAULT).
         Values are assumed to be in bytes for ingestion/query metrics.
         """
-        cutoff_recent_window = datetime.utcnow() - timedelta(days=RECENT_WINDOW_DAYS_DEFAULT)
+        cutoff_recent_window = self._utc_now() - timedelta(days=RECENT_WINDOW_DAYS_DEFAULT)
         total = 0
         for m in series or []:
             ts = m.get('timestamp')
             if not ts:
                 continue
             try:
-                t = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
+                t = self._parse_ts(ts)
             except Exception:
                 continue
             if t >= cutoff_recent_window:
@@ -87,27 +103,18 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             retention_days = self._get_from_resource(resource, 'retention_in_days')
             has_lifecycle_rules = retention_days is not None
 
-            last_collected_at = self._get_from_resource(resource, 'last_collected_at')
-
+            last_collected_at_raw = self._get_from_resource(resource, 'last_collected_at')
+            last_collection = self._parse_ts(last_collected_at_raw)
             is_dead_resource = False
-            if last_collected_at:
-                try:
-                    if isinstance(last_collected_at, (int, float)):
-                        last_collection = datetime.utcfromtimestamp(last_collected_at)
-                    else:
-                        last_collection = datetime.fromisoformat(
-                            str(last_collected_at).replace('Z', '+00:00')
-                        )
-                    is_dead_resource = (datetime.utcnow() - last_collection).days > dead_resource_days
-                except Exception:
-                    pass
+            if last_collection is not None:
+                is_dead_resource = (self._utc_now() - last_collection).days > dead_resource_days
 
             metrics = self._get_metrics(resource)
-            ingestion_metrics = metrics.get('IngestionBytes', []) or []
-            incoming_events = metrics.get('IncomingLogEvents', []) or []
+            ingestion_metrics = metrics.get(MetricKey.INGESTION.value, []) or []
+            incoming_events = metrics.get(MetricKey.EVENTS.value, []) or []
 
-            recent_ingestion = self._sum_metrics_recent_window(ingestion_metrics)
-            recent_events = self._sum_metrics_recent_window(incoming_events)
+            recent_ingestion = self._sum_metrics_last_month(ingestion_metrics)
+            recent_events = self._sum_metrics_last_month(incoming_events)
             no_recent_ingestion = (recent_ingestion == 0 and recent_events == 0)
 
             return (not has_lifecycle_rules and (no_recent_ingestion or is_dead_resource))
@@ -135,11 +142,11 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             storage_monthly_cost = compressed_gb * CWL_PRICING.storage_usd_per_gb_month
 
             metrics = self._get_metrics(resource)
-            ingestion_metrics = metrics.get('IngestionBytes', []) or []
-            query_metrics = metrics.get('QueryBytes', []) or []
+            ingestion_metrics = metrics.get(MetricKey.INGESTION.value, []) or []
+            query_metrics = metrics.get(MetricKey.QUERY.value, []) or []
 
-            ingestion_bytes = self._sum_metrics_recent_window(ingestion_metrics)
-            query_bytes = self._sum_metrics_recent_window(query_metrics)
+            ingestion_bytes = self._sum_metrics_last_month(ingestion_metrics)
+            query_bytes = self._sum_metrics_last_month(query_metrics)
 
             ingestion_gb = ingestion_bytes / BYTES_PER_GIB
             query_gb = query_bytes / BYTES_PER_GIB
@@ -152,14 +159,15 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         except Exception:
             return 0.0
     
-            
+
 
     def _get(self):
         """
         Get the inactive log groups.
         """
-        (dead_resource_days, min_storage_bytes,
-         excluded_pools, skip_cloud_accounts) = self.get_options_values()
+        (dead_resource_days,
+         excluded_pools, 
+         skip_cloud_accounts) = self.get_options_values()
 
         ca_map = self.get_cloud_accounts(SUPPORTED_CLOUD_TYPES, skip_cloud_accounts)
         _, response = self.rest_client.cloud_resources_discover(
@@ -169,7 +177,7 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         pools = self.get_pools()
 
         result = []
-        for r in response['data']:
+        for r in response.get('data', []):
             if r.get('cloud_account_id') not in ca_map:
                 continue
 
@@ -181,15 +189,15 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             if not self._is_inactive(r, dead_resource_days):
                 continue
 
-            saving = self._estimate_saving(r, min_storage_bytes)
+            saving = self._estimate_saving(r)
             ca_info = ca_map.get(r['cloud_account_id'], {})
 
             metrics = self._get_metrics(r)
-            ingestion_bytes_30d = self._sum_metrics_recent_window(metrics.get('IngestionBytes', []))
-            query_bytes_30d = self._sum_metrics_recent_window(metrics.get('QueryBytes', []))
+            ingestion_bytes_30d = self._sum_metrics_last_month(metrics.get(MetricKey.INGESTION.value, []))
+            query_bytes_30d = self._sum_metrics_last_month(metrics.get(MetricKey.QUERY.value, []))
 
             result.append({
-                'cloud_resource_id': r.get('cloud_resource_id'),
+                'cloud_resource_id': r.get('cloud_resource_id'),    
                 'resource_name': r.get('name'),
                 'log_group_name': r.get('name'),
                 'resource_id': r.get('resource_id'),
@@ -201,10 +209,10 @@ class InactiveCloudWatchLogGroup(ModuleBase):
                 'pool': self._extract_pool(r.get('pool_id'), pools),
                 'is_excluded': is_excluded,
                 'retention_in_days': self._get_from_resource(r, 'retention_in_days'),
-                'stored_bytes': self._get_from_resource(r, 'stored_bytes', 0) or 0,
-                'storage': self._get_from_resource(r, 'stored_bytes', 0) or 0,
-                'ingestion': ingestion_bytes_30d,
-                'query': query_bytes_30d,
+                'stored_bytes': int(self._get_from_resource(r, 'stored_bytes', 0) or 0),
+                'storage': int(self._get_from_resource(r, 'stored_bytes', 0) or 0),
+                'ingestion': int(ingestion_bytes_30d),
+                'query': int(query_bytes_30d),
                 'saving': saving,
             })
 

--- a/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
+++ b/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
@@ -2,28 +2,25 @@ import logging
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
-
+from enum import Enum
 from bumiworker.bumiworker.modules.base import ModuleBase
+from bumiworker.bumiworker.modules.pricing.aws_cloudwatch import CloudWatchLogsPricing
+
+SUPPORTED_CLOUD_TYPES = ("aws_cnr",)
 
 LOG = logging.getLogger(__name__)
 
+BYTES_PER_GIB = 1024 ** 3  
+RECENT_WINDOW_DAYS_DEFAULT = 30
+DAYS_THRESHOLD_DEFAULT = 7
+DEAD_RESOURCE_DAYS_DEFAULT = 30
+MIN_STORAGE_BYTES_DEFAULT = 1 * 1024 * 1024 
 
-SUPPORTED_CLOUD_TYPES = [
-    'aws_cnr'
-]
+class MetricKey(str, Enum):
+    INGESTION = "IngestionBytes"
+    EVENTS = "IncomingLogEvents"
+    QUERY = "QueryBytes"
 
-DEFAULT_DAYS_THRESHOLD = 7
-DEFAULT_DEAD_RESOURCE_DAYS = 30
-DEFAULT_MIN_STORAGE_BYTES = 1024 * 1024  # 1 MB
-BYTE_TO_GB = 1024 ** 3
-
-# Pricing and computation constants for CloudWatch Logs
-# See: https://aws.amazon.com/cloudwatch/pricing/ (values may vary by region)
-CWL_COMPRESSION_RATIO = 0.15  # Estimated compression ratio for ingested logs (~15% of original size)
-CWL_STORAGE_PRICE_PER_GB_MONTH = 0.03  # USD per GB-month (compressed)
-CWL_INGESTION_PRICE_PER_GB_30D = 0.50  # USD per GB for ingestion (last 30 days window)
-CWL_QUERY_PRICE_PER_GB_30D = 0.005  # USD per GB for query (last 30 days window)
-RECENT_WINDOW_DAYS = 30  # Days window for ingestion/query cost aggregation
 
 class InactiveCloudWatchLogGroup(ModuleBase):
     """
@@ -142,9 +139,9 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         try:
             stored_bytes = self._get_from_resource(resource, 'stored_bytes', 0) or 0
 
-            uncompressed_gb = stored_bytes / BYTE_TO_GB
-            compressed_gb = uncompressed_gb * CWL_COMPRESSION_RATIO
-            storage_monthly_cost = compressed_gb * CWL_STORAGE_PRICE_PER_GB_MONTH
+            uncompressed_gb = stored_bytes / BYTES_PER_GIB
+            compressed_gb = uncompressed_gb * CloudWatchLogsPricing.compression_factor
+            storage_monthly_cost = compressed_gb * CloudWatchLogsPricing.storage_usd_per_gb_month
 
             metrics = self._get_metrics(resource)
             ingestion_metrics = metrics.get('IngestionBytes', []) or []
@@ -153,11 +150,11 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             ingestion_bytes = self._sum_metrics_recent_window(ingestion_metrics)
             query_bytes = self._sum_metrics_recent_window(query_metrics)
 
-            ingestion_gb = ingestion_bytes / BYTE_TO_GB
-            query_gb = query_bytes / BYTE_TO_GB
+            ingestion_gb = ingestion_bytes / BYTES_PER_GIB
+            query_gb = query_bytes / BYTES_PER_GIB
 
-            ingestion_cost = ingestion_gb * CWL_INGESTION_PRICE_PER_GB_30D
-            query_cost = query_gb * CWL_QUERY_PRICE_PER_GB_30D
+            ingestion_cost = ingestion_gb * CloudWatchLogsPricing.ingestion_usd_per_gb
+            query_cost = query_gb * CloudWatchLogsPricing.query_usd_per_gb
 
             total = storage_monthly_cost + ingestion_cost + query_cost
             return round(total, 2)

--- a/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
+++ b/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
@@ -15,7 +15,15 @@ SUPPORTED_CLOUD_TYPES = [
 DEFAULT_DAYS_THRESHOLD = 7
 DEFAULT_DEAD_RESOURCE_DAYS = 30
 DEFAULT_MIN_STORAGE_BYTES = 1024 * 1024  # 1 MB
+BYTE_TO_GB = 1024 ** 3
 
+# Pricing and computation constants for CloudWatch Logs
+# See: https://aws.amazon.com/cloudwatch/pricing/ (values may vary by region)
+CWL_COMPRESSION_RATIO = 0.15  # Estimated compression ratio for ingested logs (~15% of original size)
+CWL_STORAGE_PRICE_PER_GB_MONTH = 0.03  # USD per GB-month (compressed)
+CWL_INGESTION_PRICE_PER_GB_30D = 0.50  # USD per GB for ingestion (last 30 days window)
+CWL_QUERY_PRICE_PER_GB_30D = 0.005  # USD per GB for query (last 30 days window)
+RECENT_WINDOW_DAYS = 30  # Days window for ingestion/query cost aggregation
 
 class InactiveCloudWatchLogGroup(ModuleBase):
     """
@@ -52,11 +60,12 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             return metrics
         return (resource.get('meta', {}) or {}).get('metrics', {}) or {}
 
-    def _sum_metrics_30d(self, series: List[Dict]) -> float:
+    def _sum_metrics_recent_window(self, series: List[Dict]) -> float:
         """
-        Sum the metrics for the last 30 days.
+        Sum metric values within the recent window (RECENT_WINDOW_DAYS).
+        Values are assumed to be in bytes for ingestion/query metrics.
         """
-        cutoff_30d = datetime.utcnow() - timedelta(days=30)
+        cutoff_recent_window = datetime.utcnow() - timedelta(days=RECENT_WINDOW_DAYS)
         total = 0
         for m in series or []:
             ts = m.get('timestamp')
@@ -66,7 +75,7 @@ class InactiveCloudWatchLogGroup(ModuleBase):
                 t = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
             except Exception:
                 continue
-            if t >= cutoff_30d:
+            if t >= cutoff_recent_window:
                 total += m.get('value', 0) or 0
         return total
 
@@ -76,8 +85,8 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         Check if the log group is inactive.
 
         Log group is inactive if:
-            - No lifecycle rules AND no recent ingestion, OR
-            - High storage with no recent ingestion, OR
+            - No lifecycle rules AND 
+            - No recent ingestion, OR
             - Dead resource detected
         """
         try:
@@ -103,34 +112,18 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             metrics = self._get_metrics(resource)
             ingestion_metrics = metrics.get('IngestionBytes', []) or []
             incoming_events = metrics.get('IncomingLogEvents', []) or []
-            cutoff_date = datetime.utcnow() - timedelta(days=days_threshold)
 
-            def recent_sum(series):
-                """
-                Sum the metrics for the last 30 days.
-                """
-                total = 0   
-                for m in series:
-                    ts = m.get('timestamp')
-                    if not ts:
-                        continue
-                    try:
-                        t = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
-                    except Exception:
-                        continue
-                    if t >= cutoff_date:
-                        total += m.get('value', 0) or 0
-                return total
-
-            recent_ingestion = recent_sum(ingestion_metrics)
-            recent_events = recent_sum(incoming_events)
+            recent_ingestion = self._sum_metrics_recent_window(ingestion_metrics)
+            recent_events = self._sum_metrics_recent_window(incoming_events)
             no_recent_ingestion = (recent_ingestion == 0 and recent_events == 0)
 
-            high_storage_no_ingestion = stored_bytes > min_storage_bytes and no_recent_ingestion
+            #high_storage_no_ingestion = stored_bytes > min_storage_bytes and no_recent_ingestion
 
-            return ((not has_lifecycle_rules and no_recent_ingestion) or
-                    high_storage_no_ingestion or
-                    is_dead_resource)
+            #return ((not has_lifecycle_rules and no_recent_ingestion) or
+                    #high_storage_no_ingestion or
+                    #is_dead_resource)
+            return (not has_lifecycle_rules and (no_recent_ingestion or is_dead_resource))
+
         except Exception:
             return False
 
@@ -149,39 +142,24 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         try:
             stored_bytes = self._get_from_resource(resource, 'stored_bytes', 0) or 0
 
-            uncompressed_gb = stored_bytes / (1024 ** 3)
-            compressed_gb = uncompressed_gb * 0.15
-            storage_monthly_cost = compressed_gb * 0.03
+            uncompressed_gb = stored_bytes / BYTE_TO_GB
+            compressed_gb = uncompressed_gb * CWL_COMPRESSION_RATIO
+            storage_monthly_cost = compressed_gb * CWL_STORAGE_PRICE_PER_GB_MONTH
 
             metrics = self._get_metrics(resource)
             ingestion_metrics = metrics.get('IngestionBytes', []) or []
-            query_metrics = metrics.get('QueryBytes', []) or metrics.get('Query', []) or []
-            cutoff_30d = datetime.utcnow() - timedelta(days=30)
+            query_metrics = metrics.get('QueryBytes', []) or []
 
-            def sum_recent(series):
-                total = 0
-                for m in series:
-                    ts = m.get('timestamp')
-                    if not ts:
-                        continue
-                    try:
-                        t = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
-                    except Exception:
-                        continue
-                    if t >= cutoff_30d:
-                        total += m.get('value', 0) or 0
-                return total
+            ingestion_bytes = self._sum_metrics_recent_window(ingestion_metrics)
+            query_bytes = self._sum_metrics_recent_window(query_metrics)
 
-            ingestion_bytes_30d = sum_recent(ingestion_metrics)
-            query_bytes_30d = sum_recent(query_metrics)
+            ingestion_gb = ingestion_bytes / BYTE_TO_GB
+            query_gb = query_bytes / BYTE_TO_GB
 
-            ingestion_gb_30d = ingestion_bytes_30d / (1024 ** 3)
-            query_gb_30d = query_bytes_30d / (1024 ** 3)
+            ingestion_cost = ingestion_gb * CWL_INGESTION_PRICE_PER_GB_30D
+            query_cost = query_gb * CWL_QUERY_PRICE_PER_GB_30D
 
-            ingestion_cost_30d = ingestion_gb_30d * 0.50
-            query_cost_30d = query_gb_30d * 0.005
-
-            total = storage_monthly_cost + ingestion_cost_30d + query_cost_30d
+            total = storage_monthly_cost + ingestion_cost + query_cost
             return round(total, 2)
         except Exception:
             return 0.0
@@ -219,8 +197,8 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             ca_info = ca_map.get(r['cloud_account_id'], {})
 
             metrics = self._get_metrics(r)
-            ingestion_bytes_30d = self._sum_metrics_30d(metrics.get('IngestionBytes', []))
-            query_bytes_30d = self._sum_metrics_30d(metrics.get('QueryBytes', []) or metrics.get('Query', []))
+            ingestion_bytes_30d = self._sum_metrics_recent_window(metrics.get('IngestionBytes', []))
+            query_bytes_30d = self._sum_metrics_recent_window(metrics.get('QueryBytes', []))
 
             result.append({
                 'cloud_resource_id': r.get('cloud_resource_id'),

--- a/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
+++ b/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
@@ -1,0 +1,255 @@
+import logging
+from collections import OrderedDict
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+from bumiworker.bumiworker.modules.base import ModuleBase
+
+LOG = logging.getLogger(__name__)
+
+
+SUPPORTED_CLOUD_TYPES = [
+    'aws_cnr'
+]
+
+DEFAULT_DAYS_THRESHOLD = 7
+DEFAULT_DEAD_RESOURCE_DAYS = 30
+DEFAULT_MIN_STORAGE_BYTES = 1024 * 1024  # 1 MB
+
+
+class InactiveCloudWatchLogGroup(ModuleBase):
+    """
+    Identify inactive CloudWatch Log Groups and estimate potential savings.
+    """
+    def __init__(self, organization_id, config_client, created_at):
+        super().__init__(organization_id, config_client, created_at)
+        self.option_ordered_map = OrderedDict({
+            'days_threshold': {'default': DEFAULT_DAYS_THRESHOLD},
+            'dead_resource_days': {'default': DEFAULT_DEAD_RESOURCE_DAYS},
+            'min_storage_bytes': {'default': DEFAULT_MIN_STORAGE_BYTES},
+            'excluded_pools': {
+                'default': {},
+                'clean_func': self.clean_excluded_pools,
+            },
+            'skip_cloud_accounts': {'default': []}
+        })
+
+    def _get_from_resource(self, resource: Dict, key: str, default=None):
+        """
+        Get a value from the resource.
+        """
+        meta = resource.get('meta', {}) or {}
+        if key in resource and resource.get(key) is not None:
+            return resource.get(key)
+        return meta.get(key, default)
+
+    def _get_metrics(self, resource: Dict) -> Dict:
+        """
+        Get the metrics from the resource.
+        """
+        metrics = resource.get('metrics')
+        if isinstance(metrics, dict):
+            return metrics
+        return (resource.get('meta', {}) or {}).get('metrics', {}) or {}
+
+    def _sum_metrics_30d(self, series: List[Dict]) -> float:
+        """
+        Sum the metrics for the last 30 days.
+        """
+        cutoff_30d = datetime.utcnow() - timedelta(days=30)
+        total = 0
+        for m in series or []:
+            ts = m.get('timestamp')
+            if not ts:
+                continue
+            try:
+                t = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
+            except Exception:
+                continue
+            if t >= cutoff_30d:
+                total += m.get('value', 0) or 0
+        return total
+
+    def _is_inactive(self, resource: Dict, days_threshold: int,
+                      dead_resource_days: int, min_storage_bytes: int) -> bool:
+        """
+        Check if the log group is inactive.
+
+        Log group is inactive if:
+            - No lifecycle rules AND no recent ingestion, OR
+            - High storage with no recent ingestion, OR
+            - Dead resource detected
+        """
+        try:
+            retention_days = self._get_from_resource(resource, 'retention_in_days')
+            has_lifecycle_rules = retention_days is not None
+
+            stored_bytes = self._get_from_resource(resource, 'stored_bytes', 0) or 0
+            last_collected_at = self._get_from_resource(resource, 'last_collected_at')
+
+            is_dead_resource = False
+            if last_collected_at:
+                try:
+                    if isinstance(last_collected_at, (int, float)):
+                        last_collection = datetime.utcfromtimestamp(last_collected_at)
+                    else:
+                        last_collection = datetime.fromisoformat(
+                            str(last_collected_at).replace('Z', '+00:00')
+                        )
+                    is_dead_resource = (datetime.utcnow() - last_collection).days > dead_resource_days
+                except Exception:
+                    pass
+
+            metrics = self._get_metrics(resource)
+            ingestion_metrics = metrics.get('IngestionBytes', []) or []
+            incoming_events = metrics.get('IncomingLogEvents', []) or []
+            cutoff_date = datetime.utcnow() - timedelta(days=days_threshold)
+
+            def recent_sum(series):
+                """
+                Sum the metrics for the last 30 days.
+                """
+                total = 0   
+                for m in series:
+                    ts = m.get('timestamp')
+                    if not ts:
+                        continue
+                    try:
+                        t = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
+                    except Exception:
+                        continue
+                    if t >= cutoff_date:
+                        total += m.get('value', 0) or 0
+                return total
+
+            recent_ingestion = recent_sum(ingestion_metrics)
+            recent_events = recent_sum(incoming_events)
+            no_recent_ingestion = (recent_ingestion == 0 and recent_events == 0)
+
+            high_storage_no_ingestion = stored_bytes > min_storage_bytes and no_recent_ingestion
+
+            return ((not has_lifecycle_rules and no_recent_ingestion) or
+                    high_storage_no_ingestion or
+                    is_dead_resource)
+        except Exception:
+            return False
+
+    def _estimate_saving(self, resource: Dict, min_storage_bytes: int) -> float:
+
+        """
+        Calculate potential monthly savings for an inactive log group based on AWS pricing,
+        without considering lifecycle policy changes.
+        
+        Uses three components:
+        - Ingestion (IncomingBytes): USD 0.50 per GB (last 30 days)
+        - Storage (stored_bytes): USD 0.03 per GB-month compressed (apply 0.15 compression factor)
+        - Query (QueryBytes): USD 0.005 per GB scanned (last 30 days)
+        """
+        
+        try:
+            stored_bytes = self._get_from_resource(resource, 'stored_bytes', 0) or 0
+
+            uncompressed_gb = stored_bytes / (1024 ** 3)
+            compressed_gb = uncompressed_gb * 0.15
+            storage_monthly_cost = compressed_gb * 0.03
+
+            metrics = self._get_metrics(resource)
+            ingestion_metrics = metrics.get('IngestionBytes', []) or []
+            query_metrics = metrics.get('QueryBytes', []) or metrics.get('Query', []) or []
+            cutoff_30d = datetime.utcnow() - timedelta(days=30)
+
+            def sum_recent(series):
+                total = 0
+                for m in series:
+                    ts = m.get('timestamp')
+                    if not ts:
+                        continue
+                    try:
+                        t = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
+                    except Exception:
+                        continue
+                    if t >= cutoff_30d:
+                        total += m.get('value', 0) or 0
+                return total
+
+            ingestion_bytes_30d = sum_recent(ingestion_metrics)
+            query_bytes_30d = sum_recent(query_metrics)
+
+            ingestion_gb_30d = ingestion_bytes_30d / (1024 ** 3)
+            query_gb_30d = query_bytes_30d / (1024 ** 3)
+
+            ingestion_cost_30d = ingestion_gb_30d * 0.50
+            query_cost_30d = query_gb_30d * 0.005
+
+            total = storage_monthly_cost + ingestion_cost_30d + query_cost_30d
+            return round(total, 2)
+        except Exception:
+            return 0.0
+    
+            
+
+    def _get(self):
+        """
+        Get the inactive log groups.
+        """
+        (days_threshold, dead_resource_days, min_storage_bytes,
+         excluded_pools, skip_cloud_accounts) = self.get_options_values()
+
+        ca_map = self.get_cloud_accounts(SUPPORTED_CLOUD_TYPES, skip_cloud_accounts)
+        _, response = self.rest_client.cloud_resources_discover(
+            self.organization_id, 'log_group')
+
+        employees = self.get_employees()
+        pools = self.get_pools()
+
+        result = []
+        for r in response['data']:
+            if r.get('cloud_account_id') not in ca_map:
+                continue
+
+            if r.get('pool_id') in excluded_pools:
+                is_excluded = True
+            else:
+                is_excluded = False
+
+            if not self._is_inactive(r, days_threshold, dead_resource_days, min_storage_bytes):
+                continue
+
+            saving = self._estimate_saving(r, min_storage_bytes)
+            ca_info = ca_map.get(r['cloud_account_id'], {})
+
+            metrics = self._get_metrics(r)
+            ingestion_bytes_30d = self._sum_metrics_30d(metrics.get('IngestionBytes', []))
+            query_bytes_30d = self._sum_metrics_30d(metrics.get('QueryBytes', []) or metrics.get('Query', []))
+
+            result.append({
+                'cloud_resource_id': r.get('cloud_resource_id'),
+                'resource_name': r.get('name'),
+                'log_group_name': r.get('name'),
+                'resource_id': r.get('resource_id'),
+                'cloud_account_id': r.get('cloud_account_id'),
+                'cloud_type': ca_info.get('type'),
+                'cloud_account_name': ca_info.get('name'),
+                'region': r.get('region') or self._get_from_resource(r, 'region'),
+                'owner': self._extract_owner(r.get('owner_id'), employees),
+                'pool': self._extract_pool(r.get('pool_id'), pools),
+                'is_excluded': is_excluded,
+                'retention_in_days': self._get_from_resource(r, 'retention_in_days'),
+                'stored_bytes': self._get_from_resource(r, 'stored_bytes', 0) or 0,
+                'storage': self._get_from_resource(r, 'stored_bytes', 0) or 0,
+                'ingestion': ingestion_bytes_30d,
+                'query': query_bytes_30d,
+                'saving': saving,
+            })
+
+        return result
+
+
+def main(organization_id, config_client, created_at, **kwargs):
+    return InactiveCloudWatchLogGroup(
+        organization_id, config_client, created_at
+    ).get()
+
+
+def get_module_email_name():
+    return 'Inactive CloudWatch Log Groups'

--- a/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
+++ b/bumiworker/bumiworker/modules/recommendations/inactive_cloud_watch_log_group.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 from enum import Enum
 from bumiworker.bumiworker.modules.base import ModuleBase
-from bumiworker.bumiworker.modules.pricing.aws_cloudwatch import CloudWatchLogsPricing
+from bumiworker.bumiworker.modules.pricing.aws_cloudwatch import CloudWatchLogsPricing, DEFAULT as CWL_PRICING
 
 SUPPORTED_CLOUD_TYPES = ("aws_cnr",)
 
@@ -12,7 +12,6 @@ LOG = logging.getLogger(__name__)
 
 BYTES_PER_GIB = 1024 ** 3  
 RECENT_WINDOW_DAYS_DEFAULT = 30
-DAYS_THRESHOLD_DEFAULT = 7
 DEAD_RESOURCE_DAYS_DEFAULT = 30
 MIN_STORAGE_BYTES_DEFAULT = 1 * 1024 * 1024 
 
@@ -29,9 +28,8 @@ class InactiveCloudWatchLogGroup(ModuleBase):
     def __init__(self, organization_id, config_client, created_at):
         super().__init__(organization_id, config_client, created_at)
         self.option_ordered_map = OrderedDict({
-            'days_threshold': {'default': DEFAULT_DAYS_THRESHOLD},
-            'dead_resource_days': {'default': DEFAULT_DEAD_RESOURCE_DAYS},
-            'min_storage_bytes': {'default': DEFAULT_MIN_STORAGE_BYTES},
+            'dead_resource_days': {'default': DEAD_RESOURCE_DAYS_DEFAULT},
+            'min_storage_bytes': {'default': MIN_STORAGE_BYTES_DEFAULT},
             'excluded_pools': {
                 'default': {},
                 'clean_func': self.clean_excluded_pools,
@@ -62,7 +60,7 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         Sum metric values within the recent window (RECENT_WINDOW_DAYS).
         Values are assumed to be in bytes for ingestion/query metrics.
         """
-        cutoff_recent_window = datetime.utcnow() - timedelta(days=RECENT_WINDOW_DAYS)
+        cutoff_recent_window = datetime.utcnow() - timedelta(days=RECENT_WINDOW_DAYS_DEFAULT)
         total = 0
         for m in series or []:
             ts = m.get('timestamp')
@@ -76,8 +74,7 @@ class InactiveCloudWatchLogGroup(ModuleBase):
                 total += m.get('value', 0) or 0
         return total
 
-    def _is_inactive(self, resource: Dict, days_threshold: int,
-                      dead_resource_days: int, min_storage_bytes: int) -> bool:
+    def _is_inactive(self, resource: Dict, dead_resource_days: int) -> bool:
         """
         Check if the log group is inactive.
 
@@ -90,7 +87,6 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             retention_days = self._get_from_resource(resource, 'retention_in_days')
             has_lifecycle_rules = retention_days is not None
 
-            stored_bytes = self._get_from_resource(resource, 'stored_bytes', 0) or 0
             last_collected_at = self._get_from_resource(resource, 'last_collected_at')
 
             is_dead_resource = False
@@ -114,17 +110,12 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             recent_events = self._sum_metrics_recent_window(incoming_events)
             no_recent_ingestion = (recent_ingestion == 0 and recent_events == 0)
 
-            #high_storage_no_ingestion = stored_bytes > min_storage_bytes and no_recent_ingestion
-
-            #return ((not has_lifecycle_rules and no_recent_ingestion) or
-                    #high_storage_no_ingestion or
-                    #is_dead_resource)
             return (not has_lifecycle_rules and (no_recent_ingestion or is_dead_resource))
 
         except Exception:
             return False
 
-    def _estimate_saving(self, resource: Dict, min_storage_bytes: int) -> float:
+    def _estimate_saving(self, resource: Dict) -> float:
 
         """
         Calculate potential monthly savings for an inactive log group based on AWS pricing,
@@ -140,8 +131,8 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             stored_bytes = self._get_from_resource(resource, 'stored_bytes', 0) or 0
 
             uncompressed_gb = stored_bytes / BYTES_PER_GIB
-            compressed_gb = uncompressed_gb * CloudWatchLogsPricing.compression_factor
-            storage_monthly_cost = compressed_gb * CloudWatchLogsPricing.storage_usd_per_gb_month
+            compressed_gb = uncompressed_gb * CWL_PRICING.compression_factor
+            storage_monthly_cost = compressed_gb * CWL_PRICING.storage_usd_per_gb_month
 
             metrics = self._get_metrics(resource)
             ingestion_metrics = metrics.get('IngestionBytes', []) or []
@@ -153,8 +144,8 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             ingestion_gb = ingestion_bytes / BYTES_PER_GIB
             query_gb = query_bytes / BYTES_PER_GIB
 
-            ingestion_cost = ingestion_gb * CloudWatchLogsPricing.ingestion_usd_per_gb
-            query_cost = query_gb * CloudWatchLogsPricing.query_usd_per_gb
+            ingestion_cost = ingestion_gb * CWL_PRICING.ingestion_usd_per_gb
+            query_cost = query_gb * CWL_PRICING.query_usd_per_gb
 
             total = storage_monthly_cost + ingestion_cost + query_cost
             return round(total, 2)
@@ -167,7 +158,7 @@ class InactiveCloudWatchLogGroup(ModuleBase):
         """
         Get the inactive log groups.
         """
-        (days_threshold, dead_resource_days, min_storage_bytes,
+        (dead_resource_days, min_storage_bytes,
          excluded_pools, skip_cloud_accounts) = self.get_options_values()
 
         ca_map = self.get_cloud_accounts(SUPPORTED_CLOUD_TYPES, skip_cloud_accounts)
@@ -187,7 +178,7 @@ class InactiveCloudWatchLogGroup(ModuleBase):
             else:
                 is_excluded = False
 
-            if not self._is_inactive(r, days_threshold, dead_resource_days, min_storage_bytes):
+            if not self._is_inactive(r, dead_resource_days):
                 continue
 
             saving = self._estimate_saving(r, min_storage_bytes)


### PR DESCRIPTION
# Inactive Cloud Watch Log Group - Recommendation
Identifies potentially inactive CloudWatch log groups that could generate monthly savings.

## How “inactive” is determined

* No lifecycle policy (retention_in_days not configured)

* And no recent activity (no ingestion/events in the last N days, default: 7)

* OR considered a “dead” resource (last_collected_at not updated for more than M days, default: 30)

## How savings are calculated (estimated monthly)

Based on https://aws.amazon.com/cloudwatch/pricing/ (values may vary by region)

* Storage: stored_bytes → GB → apply compression (~15%) → cost $0.03/GB-month

* Ingestion: sum of IngestionBytes over the last 30 days → GB → cost $0.50/GB

* Query: sum of QueryBytes over the last 30 days → GB → cost $0.005/GB

* Total: saving = storage_monthly_cost + ingestion_cost + query_cost (rounded to 2 decimals)