### PR TITLE
fix(frontend): type name adjustment

### DIFF
--- a/ngui/ui/src/containers/RecommendationsOverviewContainer/recommendations/InactiveCloudWatchLogGroup.tsx
+++ b/ngui/ui/src/containers/RecommendationsOverviewContainer/recommendations/InactiveCloudWatchLogGroup.tsx
@@ -71,7 +71,7 @@ const columns = [
 ];
 
 class InactiveCloudWatchLogGroup extends BaseRecommendation {
-    type = "inactive_cloudwatch_log_group";
+    type = "inactive_cloud_watch_log_group";
 
     name = "inactiveCloudWatchLogGroup";
 


### PR DESCRIPTION
## PR Description 
Aligned the type name expected by the frontend with the corresponding file name in bumiworker: "inactive_cloud_watch_log_group".