### PR TITLE
Improving imports

### DIFF
--- a/.github/workflows/test_rest-api.yaml
+++ b/.github/workflows/test_rest-api.yaml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Set up etcd service
         run: |
+          if [ "$(docker ps -aq -f name=^/etcd$)" ]; then
+            docker rm -f etcd
+          fi
           docker run -d --name etcd -p 2379:2379 -p 2380:2380 \
             quay.io/coreos/etcd:v3.5 \
             etcd \
@@ -49,3 +52,13 @@ jobs:
         env:
           ETCD_HOST: http://127.0.0.1:2379
         run: bash -x rest_api/run_test.sh
+
+      - name: Stop and remove etcd container
+        if: ${{ always() }}
+        run: |
+          if [ "$(docker ps -q -f name=^/etcd$)" ]; then
+            docker stop etcd || true
+          fi
+          if [ "$(docker ps -aq -f name=^/etcd$)" ]; then
+            docker rm etcd || true
+          fi

--- a/.github/workflows/test_rest-api.yaml
+++ b/.github/workflows/test_rest-api.yaml
@@ -1,13 +1,13 @@
+---
 name: Build restapi test image and run tests on it
-run-name: Build restapi test image and run tests on it - started by ${{ github.actor }}
+run-name: Build restapi test image and run tests on it
 permissions: read-all
 on:
   pull_request:
     types: [opened, synchronize]
     paths:
-    - 'rest_api/**'
+      - "rest_api/**"
   workflow_dispatch:
-
 
 jobs:
   build_image:
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
       - name: Login to Docker Hub (optional)
         env:
           username: ${{ secrets.EXT_DOCKER_LOGIN }}
@@ -24,7 +25,27 @@ jobs:
         with:
           username: ${{ env.username }}
           password: ${{ env.password }}
+
+      - name: Set up etcd service
+        run: |
+          docker run -d --name etcd -p 2379:2379 -p 2380:2380 \
+            quay.io/coreos/etcd:v3.5 \
+            etcd \
+            --listen-peer-urls http://0.0.0.0:2380 \
+            --listen-client-urls http://0.0.0.0:2379 \
+            --advertise-client-urls http://127.0.0.1:2379 \
+            --initial-cluster-token etcd-cluster-1 \
+            --initial-advertise-peer-urls http://127.0.0.1:2380 \
+            --initial-cluster default=http://127.0.0.1:2380
+
+      - name: Verify etcd is running
+        run: |
+          curl -L http://127.0.0.1:2379/health
+
       - name: Build image
         run: bash -x build.sh rest_api build
+
       - name: Build test image and run tests
+        env:
+          ETCD_HOST: http://127.0.0.1:2379
         run: bash -x rest_api/run_test.sh

--- a/.github/workflows/test_rest-api.yaml
+++ b/.github/workflows/test_rest-api.yaml
@@ -32,7 +32,7 @@ jobs:
             docker rm -f etcd
           fi
           docker run -d --name etcd -p 2379:2379 -p 2380:2380 \
-            quay.io/coreos/etcd:v3.5 \
+            quay.io/coreos/etcd:v3.5.9 \
             etcd \
             --listen-peer-urls http://0.0.0.0:2380 \
             --listen-client-urls http://0.0.0.0:2379 \

--- a/diworker/diworker/main.py
+++ b/diworker/diworker/main.py
@@ -2,6 +2,7 @@
 import os
 import time
 import logging
+from queue import Queue as ThreadQueue, Empty
 
 import urllib3
 from concurrent.futures import ThreadPoolExecutor
@@ -39,6 +40,7 @@ LOG = logging.getLogger(__name__)
 ENVIRONMENT_CLOUD_TYPE = 'environment'
 HEARTBEAT_INTERVAL = 300
 DEFAULT_MAX_WORKERS = 4
+DEFAULT_REPORT_IMPORT_TIMEOUT = 60 * 60 * 4  # 4 hours
 
 
 class DIWorker(ConsumerMixin):
@@ -54,6 +56,10 @@ class DIWorker(ConsumerMixin):
         self.thread = Thread(
             target=self.heartbeat, args=(self.config_cl_params,))
         self.thread.start()
+        timeout_setting = self.diworker_settings.get(
+            'report_import_timeout', DEFAULT_REPORT_IMPORT_TIMEOUT)
+        self.report_import_timeout = int(
+            timeout_setting or DEFAULT_REPORT_IMPORT_TIMEOUT)
         self.executor = ThreadPoolExecutor(
             max_workers=int(
                 self.diworker_settings.get(
@@ -240,26 +246,104 @@ class DIWorker(ConsumerMixin):
             'cloud_account', 'report_import_failed',
             'organization.report_import.failed')
 
-    def process_task(self, body, message):
-        self.executor.submit(self._process_task, body, message)
+    def _report_import_worker(self, body, result_queue):
+        config_cl = self.get_config_cl(self.config_cl_params)
+        rest_cl = self.get_rest_cl(config_cl)
+        mongo_cl = self.get_mongo_cl(config_cl)
+        clickhouse_cl = self.get_clickhouse_cl(config_cl)
+        task_exception = None
+        try:
+            self.report_import(
+                body,
+                config_cl=config_cl,
+                rest_cl=rest_cl,
+                mongo_cl=mongo_cl,
+                clickhouse_cl=clickhouse_cl
+            )
+        except Exception as exc:
+            task_exception = exc
+        finally:
+            result_queue.put(task_exception)
+            mongo_cl.close()
+            clickhouse_cl.close()
+            rest_cl.close()
+            with self.active_reports_lock:
+                self.active_report_import_ids.discard(
+                    body.get('report_import_id'))
 
-    def _process_task(self, body, message):
+    def _handle_import_timeout(self, body):
+        report_import_id = body.get('report_import_id')
+        if not report_import_id:
+            LOG.error('Failed to handle timeout: report id is missing in %s',
+                      body)
+            return
+        reason = 'Import timeout after %s seconds' % self.report_import_timeout
+        LOG.error('Report import %s timed out after %s seconds',
+                  report_import_id, self.report_import_timeout)
         config_cl = self.get_config_cl(self.config_cl_params)
         rest_cl = self.get_rest_cl(config_cl)
         mongo_cl = self.get_mongo_cl(config_cl)
         clickhouse_cl = self.get_clickhouse_cl(config_cl)
         try:
-            self.report_import(body, config_cl=config_cl, rest_cl=rest_cl,
-                               mongo_cl=mongo_cl, clickhouse_cl=clickhouse_cl)
+            rest_cl.report_import_update(
+                report_import_id,
+                {'state': 'failed', 'state_reason': reason}
+            )
+            _, import_dict = rest_cl.report_import_get(report_import_id)
+            cloud_account_id = import_dict.get('cloud_account_id')
+            _, ca = rest_cl.cloud_account_get(cloud_account_id)
+            previous_attempt_ts = ca.get('last_import_attempt_at', 0)
+            importer_params = {
+                'cloud_account_id': cloud_account_id,
+                'rest_cl': rest_cl,
+                'config_cl': config_cl,
+                'mongo_raw': mongo_cl.restapi['raw_expenses'],
+                'mongo_resources': mongo_cl.restapi['resources'],
+                'clickhouse_cl': clickhouse_cl,
+                'import_file': import_dict.get('import_file'),
+                'recalculate': import_dict.get('is_recalculation', False)
+            }
+            importer = BaseReportImporter(**importer_params)
+            now = int(time.time())
+            importer.update_cloud_import_attempt(now, reason)
+            self.send_report_failed_email(ca, previous_attempt_ts, now)
         except Exception as exc:
-            LOG.exception('Data import failed: %s', str(exc))
+            LOG.exception(
+                'Failed to handle timeout for report import %s: %s',
+                report_import_id, str(exc))
         finally:
             mongo_cl.close()
             clickhouse_cl.close()
             rest_cl.close()
             with self.active_reports_lock:
-                self.active_report_import_ids.discard(body.get('report_import_id'))
-        message.ack()
+                self.active_report_import_ids.discard(report_import_id)
+
+    def process_task(self, body, message):
+        self.executor.submit(self._process_task, body, message)
+
+    def _process_task(self, body, message):
+        result_queue = ThreadQueue(maxsize=1)
+        worker_thread = Thread(
+            target=self._report_import_worker,
+            args=(body, result_queue),
+            daemon=True
+        )
+        worker_thread.start()
+        try:
+            worker_thread.join(timeout=self.report_import_timeout)
+            if worker_thread.is_alive():
+                self._handle_import_timeout(body)
+            else:
+                try:
+                    task_exception = result_queue.get_nowait()
+                except Empty:
+                    task_exception = None
+                if task_exception:
+                    raise task_exception
+        except Exception as exc:
+            LOG.exception('Data import failed: %s', str(exc))
+        finally:
+            message.ack()
 
 
 if __name__ == '__main__':

--- a/diworker/diworker/main.py
+++ b/diworker/diworker/main.py
@@ -40,7 +40,10 @@ LOG = logging.getLogger(__name__)
 ENVIRONMENT_CLOUD_TYPE = 'environment'
 HEARTBEAT_INTERVAL = 300
 DEFAULT_MAX_WORKERS = 4
-DEFAULT_REPORT_IMPORT_TIMEOUT = 60 * 60 * 4  # 4 hours
+# Allow overriding the default timeout through env for deployments
+DEFAULT_REPORT_IMPORT_TIMEOUT = int(
+    os.environ.get('DEFAULT_REPORT_IMPORT_TIMEOUT', 60 * 60 * 4)
+)
 
 
 class DIWorker(ConsumerMixin):

--- a/optscale-deploy/optscale/templates/diworker.yaml
+++ b/optscale-deploy/optscale/templates/diworker.yaml
@@ -45,3 +45,5 @@ spec:
           value: {{ .Values.etcd.service.externalPort | quote }}
         - name: FAKE_CAD_ENABLED
           value: {{ .Values.fake_cad_enabled | quote }}
+        - name: DEFAULT_REPORT_IMPORT_TIMEOUT
+          value: {{ $config.reportImportTimeout | default "14400" | quote }}

--- a/optscale-deploy/optscale/values.yaml
+++ b/optscale-deploy/optscale/values.yaml
@@ -255,6 +255,7 @@ diworker:
     repository: *diworker_name
     tag: *tag
     pullPolicy: Never
+  reportImportTimeout: 14400
 
 katara_service:
   name: &katara_name katara

--- a/rest_api/rest_api_server/controllers/report_import.py
+++ b/rest_api/rest_api_server/controllers/report_import.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 import tools.optscale_time as opttime
 from sqlalchemy import and_, true, or_, exists
+from sqlalchemy.orm import sessionmaker, joinedload
 import boto3
 from tools.optscale_exceptions.common_exc import (
     NotFoundException, FailedDependency, WrongArgumentsException
@@ -24,6 +25,7 @@ from rest_api.rest_api_server.utils import (raise_unexpected_exception,
 ACTIVE_IMPORT_THRESHOLD = 1800  # 30 min
 DEFAULT_NOT_PROCESSED_REPORT_THRESHOLD_SECONDS = 10800  # 3 hrs
 DEFAULT_QUEUE_MESSAGE_EXPIRATION_SECONDS = 10800  # 3 hrs
+DEFAULT_IN_PROGRESS_TIMEOUT_SECONDS = 3600  # 1 hr
 LOG = logging.getLogger(__name__)
 
 
@@ -34,6 +36,27 @@ class ReportImportBaseController(BaseController):
     REPORT_IMPORT_QUEUE = 'report-imports'
     RETRY_POLICY = {'max_retries': 15, 'interval_start': 0,
                     'interval_step': 1, 'interval_max': 3}
+
+    def _get_in_progress_timeout(self):
+        timeout_value = self._config.report_imports_setting().get(
+            'in_progress_timeout_secs',
+            DEFAULT_IN_PROGRESS_TIMEOUT_SECONDS
+        )
+        try:
+            timeout_seconds = int(timeout_value)
+        except (TypeError, ValueError):
+            timeout_seconds = DEFAULT_IN_PROGRESS_TIMEOUT_SECONDS
+        return max(timeout_seconds, 0)
+
+    def _expire_in_progress_imports_safe(self, cloud_account_id):
+        """Fail-safe watchdog never propagates exceptions to callers."""
+        try:
+            self._expire_in_progress_imports(cloud_account_id)
+        except Exception:
+            LOG.exception(
+                'Failed to expire stale report imports for cloud account %s',
+                cloud_account_id
+            )
 
     def create(self, cloud_account_id, import_file=None, recalculate=False, priority=1):
         report_import = super().create(
@@ -47,7 +70,50 @@ class ReportImportBaseController(BaseController):
                 report_import, 'recalculation_started')
         return report_import
 
+    def _expire_in_progress_imports(self, cloud_account_id):
+        timeout_seconds = self._get_in_progress_timeout()
+        if timeout_seconds <= 0:
+            return
+        expiration_ts = opttime.utcnow_timestamp() - timeout_seconds
+        engine = self.session.bind
+        session_factory = sessionmaker(bind=engine)
+        local_session = session_factory()
+        try:
+            expired_imports = local_session.query(ReportImport).options(
+                joinedload(ReportImport.cloud_account)
+            ).filter(
+                ReportImport.cloud_account_id == cloud_account_id,
+                ReportImport.deleted_at.is_(False),
+                ReportImport.state == ImportStates.IN_PROGRESS,
+                ReportImport.created_at <= expiration_ts
+            ).all()
+            if not expired_imports:
+                return
+            reason = 'Import timeout after %s seconds' % timeout_seconds
+            now = opttime.utcnow_timestamp()
+            for report in expired_imports:
+                LOG.warning(
+                    'Marking report import %s as failed due to timeout (%ss)',
+                    report.id, timeout_seconds
+                )
+                report.state = ImportStates.FAILED.value
+                report.state_reason = reason
+                report.updated_at = now
+            local_session.commit()
+            for report in expired_imports:
+                if report.is_recalculation:
+                    self._publish_report_import_activity(
+                        report, 'recalculation_failed',
+                        error_reason=reason, level='ERROR')
+                else:
+                    self._publish_report_import_activity(
+                        report, 'report_import_failed',
+                        error_reason=reason, level='ERROR')
+        finally:
+            local_session.close()
+
     def check_unprocessed_imports(self, cloud_account_id):
+        self._expire_in_progress_imports_safe(cloud_account_id)
         dt = opttime.utcnow().timestamp()
         scheduled_threshold = dt - int(
             self._config.report_imports_setting().get(
@@ -356,6 +422,7 @@ class ReportImportFileController(ReportImportBaseController):
 
     def list(self, cloud_account_id, show_completed=False, show_active=False):
         self.check_cloud_account(cloud_account_id)
+        self._expire_in_progress_imports_safe(cloud_account_id)
         query = self.session.query(self.model_type).filter(
             self.model_type.deleted_at.is_(False),
             self.model_type.cloud_account_id == cloud_account_id,
@@ -376,6 +443,7 @@ class ReportImportFileController(ReportImportBaseController):
         report = super().get(item_id, **kwargs)
         if report:
             self.check_cloud_account(report.cloud_account_id)
+            self._expire_in_progress_imports_safe(report.cloud_account_id)
         return report
 
     def check_cloud_account(self, cloud_account_id):


### PR DESCRIPTION
- Added a configurable watchdog inside ReportImportBaseController so any IN_PROGRESS report import that exceeds the timeout is automatically marked FAILED, unblocking new imports and ensuring activity logs/state_reason reflect the timeout.
- Reworked diworker task execution to run each import in a dedicated thread with a hard timeout: if the thread hangs, we now mark the import as failed, update attempt metadata, send the failure notification, and still ACK the RabbitMQ message.