### PR TITLE
fix abandoned amazon s3 bucket recommendation 

### DIFF
--- a/bumiworker/bumiworker/modules/abandoned_base.py
+++ b/bumiworker/bumiworker/modules/abandoned_base.py
@@ -78,8 +78,18 @@ class S3AbandonedBucketsBase(AbandonedBase):
     def _are_below_thresholds(res_data_request_map, metric_threshold_map):
         resource_ids = []
         for res_id, data_request_map in res_data_request_map.items():
-            if all(data_request_map.get(key, 0) <= threshold_value
-                   for key, threshold_value in metric_threshold_map.items()):
+            checks = {
+                key: data_request_map.get(key, 0) <= threshold_value
+                for key, threshold_value in metric_threshold_map.items()
+            }
+            LOG.debug(
+                'AB - Resource %s threshold checks: values=%s thresholds=%s checks=%s',
+                res_id,
+                data_request_map,
+                metric_threshold_map,
+                checks
+            )
+            if all(checks.values()):
                 resource_ids.append(res_id)
         LOG.debug(f'AB - Resources below thresholds: {resource_ids}')
         return resource_ids

--- a/bumiworker/bumiworker/modules/abandoned_base.py
+++ b/bumiworker/bumiworker/modules/abandoned_base.py
@@ -78,20 +78,10 @@ class S3AbandonedBucketsBase(AbandonedBase):
     def _are_below_thresholds(res_data_request_map, metric_threshold_map):
         resource_ids = []
         for res_id, data_request_map in res_data_request_map.items():
-            checks = {
-                key: data_request_map.get(key, 0) <= threshold_value
-                for key, threshold_value in metric_threshold_map.items()
-            }
-            LOG.debug(
-                'AB - Resource %s threshold checks: values=%s thresholds=%s checks=%s',
-                res_id,
-                data_request_map,
-                metric_threshold_map,
-                checks
-            )
-            if all(checks.values()):
+            if all(data_request_map.get(key, 0) <= threshold_value
+                   for key, threshold_value in metric_threshold_map.items()):
                 resource_ids.append(res_id)
-        LOG.debug(f'AB - Resources below thresholds: {resource_ids}')
+        LOG.info(f'AB - Resources below thresholds: {resource_ids}')
         return resource_ids
 
     @staticmethod

--- a/bumiworker/bumiworker/modules/abandoned_base.py
+++ b/bumiworker/bumiworker/modules/abandoned_base.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from bumiworker.bumiworker.modules.base import (
-    LOG, ArchiveBase, ArchiveReason, ModuleBase, DAYS_IN_MONTH
+    ArchiveBase, ArchiveReason, ModuleBase, DAYS_IN_MONTH
 )
 from tools.optscale_data.clickhouse import ExternalDataConverter
 from tools.optscale_time import utcnow, startday
@@ -81,7 +81,6 @@ class S3AbandonedBucketsBase(AbandonedBase):
             if all(data_request_map.get(key, 0) <= threshold_value
                    for key, threshold_value in metric_threshold_map.items()):
                 resource_ids.append(res_id)
-        LOG.info(f'AB - Resources below thresholds: {resource_ids}')
         return resource_ids
 
     @staticmethod
@@ -106,8 +105,6 @@ class S3AbandonedBucketsBase(AbandonedBase):
     def _get(self):
         now = utcnow()
         start_date = now - timedelta(days=self.days_threshold)
-
-        LOG.debug(f'AB - Start date for abandoned buckets: {start_date}')
 
         cloud_accounts = self.get_cloud_accounts(self.SUPPORTED_CLOUD_TYPES,
                                                  self.skip_cloud_accounts)
@@ -162,8 +159,6 @@ class S3AbandonedBucketsBase(AbandonedBase):
                         base_result_dict.update(
                             self.metrics_result(data_req_map))
                         result.append(base_result_dict)
-
-        LOG.debug(f'AB - Abandoned buckets result: {result}')
 
         return result
 

--- a/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
+++ b/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
@@ -30,14 +30,11 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
     def get_metric_threshold_map(self):
         # Buckets are considered abandoned if both GetObject and PutObject
         # operations are zero (no read or write activity)
-        metric_threshold_map = {
+        LOG.info(f'AB - GET_OBJECT_KEY: {GET_OBJECT_KEY}, PUT_OBJECT_KEY: {PUT_OBJECT_KEY}')
+        return {
             GET_OBJECT_KEY: False,
             PUT_OBJECT_KEY: False
         }
-        LOG.info(
-            'AB - Metric threshold map loaded: %s (abandoned when both false)',
-            metric_threshold_map)
-        return metric_threshold_map
 
     def _get_data_size_request_metrics(self, cloud_account_id,
                                        cloud_resource_ids, start_date,
@@ -104,15 +101,10 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
 
     @staticmethod
     def metrics_result(data_req_map):
-        result = {
+        return {
             'get_object_count': data_req_map.get(GET_OBJECT_KEY, False),
             'put_object_count': data_req_map.get(PUT_OBJECT_KEY, False),
         }
-        LOG.info(
-            'AB - metrics_result mapping: %s -> %s',
-            data_req_map,
-            result)
-        return result
 
 
 def main(organization_id, config_client, created_at, **kwargs):

--- a/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
+++ b/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
@@ -80,7 +80,6 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
             operation = api_request['_id']['operation']
             usage_amounts = api_request['usage_amount']
             total_sum = sum(float(amount) for amount in usage_amounts) if usage_amounts else 0
-            LOG.info(f'AB - Resource {cloud_resource_id} operation {operation} total usage amount: {total_sum}')
             has_usage = bool(total_sum)
             if operation == 'GetObject':
                 resource_meter_value[cloud_resource_id][
@@ -89,15 +88,6 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
                 resource_meter_value[cloud_resource_id][
                     PUT_OBJECT_KEY] = has_usage
 
-        for resource_id, meter_values in resource_meter_value.items():
-            LOG.info(
-                'AB - Resource %s operations status: get_object=%s put_object=%s',
-                resource_id,
-                meter_values[GET_OBJECT_KEY],
-                meter_values[PUT_OBJECT_KEY],
-            )
-
-        LOG.info(f'AB - Resource meter values: {resource_meter_value}')
         return resource_meter_value
 
     @staticmethod

--- a/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
+++ b/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
@@ -30,11 +30,14 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
     def get_metric_threshold_map(self):
         # Buckets are considered abandoned if both GetObject and PutObject
         # operations are zero (no read or write activity)
-        LOG.debug(f'AB - GET_OBJECT_KEY: {GET_OBJECT_KEY}, PUT_OBJECT_KEY: {PUT_OBJECT_KEY}')
-        return {
+        metric_threshold_map = {
             GET_OBJECT_KEY: False,
             PUT_OBJECT_KEY: False
         }
+        LOG.info(
+            'AB - Metric threshold map loaded: %s (abandoned when both false)',
+            metric_threshold_map)
+        return metric_threshold_map
 
     def _get_data_size_request_metrics(self, cloud_account_id,
                                        cloud_resource_ids, start_date,
@@ -68,7 +71,6 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
         api_requests = self.mongo_client.restapi.raw_expenses.aggregate(
             api_request_pipeline)
         api_requests_list = list(api_requests)
-        LOG.debug(f'AB - API Requests aggregation result: {api_requests_list}')
         resource_meter_value = {}
         # Initialize all resources with no recorded activity
         for res_id in cloud_resource_ids:
@@ -89,15 +91,28 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
                 resource_meter_value[cloud_resource_id][
                     PUT_OBJECT_KEY] = has_usage
 
-        LOG.debug(f'AB - Resource meter values: {resource_meter_value}')
+        for resource_id, meter_values in resource_meter_value.items():
+            LOG.info(
+                'AB - Resource %s operations status: get_object=%s put_object=%s',
+                resource_id,
+                meter_values[GET_OBJECT_KEY],
+                meter_values[PUT_OBJECT_KEY],
+            )
+
+        LOG.info(f'AB - Resource meter values: {resource_meter_value}')
         return resource_meter_value
 
     @staticmethod
     def metrics_result(data_req_map):
-        return {
+        result = {
             'get_object_count': data_req_map.get(GET_OBJECT_KEY, False),
             'put_object_count': data_req_map.get(PUT_OBJECT_KEY, False),
         }
+        LOG.info(
+            'AB - metrics_result mapping: %s -> %s',
+            data_req_map,
+            result)
+        return result
 
 
 def main(organization_id, config_client, created_at, **kwargs):

--- a/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
+++ b/bumiworker/bumiworker/modules/recommendations/s3_abandoned_buckets.py
@@ -30,7 +30,6 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
     def get_metric_threshold_map(self):
         # Buckets are considered abandoned if both GetObject and PutObject
         # operations are zero (no read or write activity)
-        LOG.info(f'AB - GET_OBJECT_KEY: {GET_OBJECT_KEY}, PUT_OBJECT_KEY: {PUT_OBJECT_KEY}')
         return {
             GET_OBJECT_KEY: False,
             PUT_OBJECT_KEY: False
@@ -59,8 +58,8 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
                         '_id': '$resource_id',
                         'operation': '$lineItem/Operation'
                     },
-                    'total_usage': {
-                        '$sum': '$lineItem/UsageAmount'
+                    'usage_amount': {
+                        '$push': '$lineItem/UsageAmount'
                     }
                 }
             }
@@ -75,11 +74,13 @@ class S3AbandonedBuckets(S3AbandonedBucketsBase):
                 GET_OBJECT_KEY: False,
                 PUT_OBJECT_KEY: False
             }
-        # Aggregate operation usage (already summed by MongoDB)
+        # Aggregate operation usage by summing the pushed amounts
         for api_request in api_requests_list:
             cloud_resource_id = api_request['_id']['_id']
             operation = api_request['_id']['operation']
-            total_sum = int(api_request['total_usage'])
+            usage_amounts = api_request['usage_amount']
+            total_sum = sum(float(amount) for amount in usage_amounts) if usage_amounts else 0
+            LOG.info(f'AB - Resource {cloud_resource_id} operation {operation} total usage amount: {total_sum}')
             has_usage = bool(total_sum)
             if operation == 'GetObject':
                 resource_meter_value[cloud_resource_id][


### PR DESCRIPTION
Fix MongoDB aggregation for usage_amount

Previously, the MongoDB query was aggregating usage_amount values directly in the pipeline. However, since usage_amount is stored as a string, MongoDB ignored these values during the sum operation, resulting in totals always being 0.

This change updates the logic to:

Retrieve all usage_amount values without aggregating in the query
Sum in the application layer after proper type handling